### PR TITLE
updated hibernate validator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.13.Final</version>
+			<version>6.0.20.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>


### PR DESCRIPTION
updated hibernate validator version from 6.0.13 to 6.0.20 because of security vulnerabilities with older ver.