### PR TITLE
updated event index page and single event show page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ build/
 
 src/main/resources/application.properties
 
-/src/main/resources/static/keys.js
+/src/main/resources/static/js/keys.js

--- a/src/main/java/com/agentlink/agentlink/controllers/EventsController.java
+++ b/src/main/java/com/agentlink/agentlink/controllers/EventsController.java
@@ -34,9 +34,9 @@ public class EventsController {
         this.applicationsDao = applicationsDao;
     }
 
-    @RequestMapping(path = "/events", method = RequestMethod.GET)
+    @GetMapping("/events")
     public String getAllEvents(Model model) {
-        List<OpenHouseEvent> openHouseEvents = openHouseEventsDao.findAll();
+        List<OpenHouseEvent> openHouseEvents = openHouseEventsDao.findAllWithoutHostWhereDateStartAfter(new Date());
         model.addAttribute("house", housesDao);
         model.addAttribute("openHouseEvents", openHouseEvents);
         return "openHouseEvents/index";

--- a/src/main/java/com/agentlink/agentlink/repositories/OpenHouseEventRepository.java
+++ b/src/main/java/com/agentlink/agentlink/repositories/OpenHouseEventRepository.java
@@ -14,16 +14,20 @@ public interface OpenHouseEventRepository extends JpaRepository<OpenHouseEvent, 
     @Query("FROM OpenHouseEvent O WHERE O.house.address LIKE %:query%")
     List<OpenHouseEvent> findAllQuery(String query);
 
-    // Finds all events by event creator (house.user.id) id where the event start date/time has not reached the input date/time
+    // Finds all events without a host that start after the input date
+    @Query("FROM OpenHouseEvent O WHERE O.dateStart >= ?1 AND O.user.id = O.house.user.id")
+    List<OpenHouseEvent> findAllWithoutHostWhereDateStartAfter(Date date);
+
+    // Finds all events by event creator (house.user.id) id that start after the input date
     @Query("FROM OpenHouseEvent O WHERE O.house.user.id = ?1 AND O.dateStart >= ?2")
     List<OpenHouseEvent> findAllByCreatorIdAndDateStartAfter(long id, Date date);
 
-    // Finds all events by event creator (house.user.id) id where the event end date/time has passed the input date/time.
+    // Finds all events by event creator (house.user.id) id that have ended after the input date
     @Query("FROM OpenHouseEvent O WHERE O.house.user.id = ?1 AND O.dateEnd <= ?2")
     List<OpenHouseEvent> findAllByCreatorIdAndDateEndBefore(long id, Date date);
 
 
-    // Finds all events by user id where an user has been set to host and the event has not passed the input date/time.
+    // Finds all events by user id where an user has been set to host and that start after the input date
     @Query("FROM OpenHouseEvent O WHERE O.user.id = ?1 AND O.house.user.id <> O.user.id AND O.dateStart >= ?2")
     List<OpenHouseEvent> findAllByHostedByUserIdAndDateStartAfter(long id, Date date);
 

--- a/src/main/resources/templates/openHouseEvents/show.html
+++ b/src/main/resources/templates/openHouseEvents/show.html
@@ -16,12 +16,8 @@
 
 <div class="container py-3">
     <div class="title h1 text-dark text-center">
-        <h4 id="houseAddress"><span th:text="${openHouseEvent.house.address}"/>, <span
-                th:text="${openHouseEvent.house.city}"/>, <span th:text="${openHouseEvent.house.state}"/>
-            <span
-                    th:text="${openHouseEvent.house.zipcode}"/></h4>
+        <h4 id="houseAddress"><span th:text="${openHouseEvent.house.address}"/>, <span th:text="${openHouseEvent.house.city}"/>, <span th:text="${openHouseEvent.house.state}"/><span th:text="${openHouseEvent.house.zipcode}"/></h4>
     </div>
-
     <div class="card">
         <div class="row">
             <div class="col-md-7 px-3">
@@ -41,26 +37,20 @@
                     </p>
                 </div>
                 <div class="row d-flex justify-content-center">
-                    <div class="text-center"
-                         th:if="${isEventCreator && currentDateTime.before(openHouseEvent.dateStart)}">
+                    <div sec:authorize="isAuthenticated()" class="text-center" th:if="${isEventCreator && currentDateTime.before(openHouseEvent.dateStart)}">
                         <a th:href="@{/events/edit/{id}(id=${openHouseEvent.id})}" class="btn btn-primary btn-width">Edit</a>
                         <form th:action="@{/events/delete/{id}(id=${openHouseEvent.id})}" method="post" class="d-flex justify-content-center">
                             <input type="submit" value="Delete" class="btn btn-danger btn-width">
                         </form>
                     </div>
-                    <a sec:authorize="isAuthenticated()"
-                       th:if="${!isEventCreator && hasNotApplied && currentDateTime.before(openHouseEvent.dateStart)}"
-                       th:href="@{/events/apply/{id}(id=${openHouseEvent.id})}" class="btn btn-primary">Apply</a>
+                    <a sec:authorize="isAuthenticated()" th:if="${!isEventCreator && hasNotApplied && currentDateTime.before(openHouseEvent.dateStart)}" th:href="@{/events/apply/{id}(id=${openHouseEvent.id})}" class="btn btn-primary">Apply</a>
                 </div>
             </div>
-
             <div class="col-md-5">
                 <div class="advisor_thumb"><img th:src="${openHouseEvent.house.image_url}" width="525" height="345" alt="HOUSE IMAGE"></div>
             </div>
         </div>
-
     </div>
-
 </div>
 <!--mapbox here-->
 <div class="row justify-content-center mb-4">
@@ -71,18 +61,16 @@
     <div style="width: 30rem;" class="card" th:if="${isEventCreator && openHouseEvent.feedback != null}">
         <h3>Event feedback:</h3>
         <div class="card-body">
-            <p>Host name: <span th:text="${openHouseEvent.user.firstName}"/> <span
-                    th:text="${openHouseEvent.user.lastName}"/></p>
+            <p>Host name: <span th:text="${openHouseEvent.user.firstName}"/> <span th:text="${openHouseEvent.user.lastName}"/></p>
             <p>Feedback: <span th:text="${openHouseEvent.feedback}"/></p>
         </div>
     </div>
-    <div th:if="${isEventCreator && currentDateTime.before(openHouseEvent.dateStart)}">
+    <div sec:authorize="isAuthenticated()" th:if="${isEventCreator && currentDateTime.before(openHouseEvent.dateStart)}">
         <h3 th:if="${!applications.isEmpty()}">Applicants</h3>
         <div style="width: 30rem;" class="card" th:each="app : ${applications}">
             <div class="card-body">
                 <p>Application date: <span th:text="${#dates.format(app.date, 'MMM-dd-yyyy h:mm a')}"/></p>
-                <p>Applicant name: <a th:href="@{/profile/{id}(id=${app.user.id})}"> <span
-                        th:text="${app.user.firstName}"/> <span th:text="${app.user.lastName}"/></a></p>
+                <p>Applicant name: <a th:href="@{/profile/{id}(id=${app.user.id})}"> <span th:text="${app.user.firstName}"/> <span th:text="${app.user.lastName}"/></a></p>
                 <p>Inquiry: <span th:text="${app.inquiry}"/></p>
                 <form th:action="@{/events/apply/host/{eventId}/{userId} (eventId=${openHouseEvent.id}, userId=${app.user.id})}"
                       method="post">


### PR DESCRIPTION
Updated events index page to only show non hosted events that have not started

Added method in events repo to grab all events without a host that have not started

Fixed some issues with single event show page where a non user would get an error