### PR TITLE
updated edit and creation of user listings with images

### DIFF
--- a/src/main/java/com/agentlink/agentlink/controllers/HousesController.java
+++ b/src/main/java/com/agentlink/agentlink/controllers/HousesController.java
@@ -83,7 +83,7 @@ public class HousesController {
     }
 
     @PostMapping("/houses/create")
-    public String createHouse(@Valid @ModelAttribute House house, BindingResult result, Model model) {
+    public String createHouse(@Valid @ModelAttribute House house, BindingResult result, Model model, @RequestParam(defaultValue = "https://cdn.filestackcontent.com/PegYCiOTcq8FxHmHl4nG") String image_url) {
         User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() != "anonymousUser") {
             User user = usersDao.getById(currentUser.getId());
@@ -94,6 +94,12 @@ public class HousesController {
         if (result.hasErrors()) {
             return "houses/create";
         }
+
+        // If the house img url value is not the default, then this will set the users uploaded img url as the value.
+        if (!house.getImage_url().equals("https://cdn.filestackcontent.com/PegYCiOTcq8FxHmHl4nG")) {
+            house.setImage_url(image_url);
+        }
+
         // Verifies the current user is a listing agent
         if (usersDao.getById(currentUser.getId()).isListingAgent()) {
             housesDao.save(house);
@@ -173,20 +179,20 @@ public class HousesController {
 //        }
 //        return "redirect:/houses";
 //    }
-
-    @PostMapping("/houses/delete/{id}/image")
-    public String deleteHouseImage(@PathVariable Long id, Model model){
-        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() != "anonymousUser") {
-            User user = usersDao.getById(currentUser.getId());
-            model.addAttribute("user", user);
-        }
-        House houseFromDb = housesDao.getById(id);
-        model.addAttribute("house", houseFromDb);
-        model.addAttribute("states", states);
-        if (currentUser.getId() == houseFromDb.getUser().getId()) {
-            houseFromDb.setImage_url(null);
-        }
-        return "houses/edit";
-    }
+    // Removed ability to delete uploaded images, we only offer the option to upload a new image (overwrite old or default)
+//    @PostMapping("/houses/delete/{id}/image")
+//    public String deleteHouseImage(@PathVariable Long id, Model model){
+//        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+//        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() != "anonymousUser") {
+//            User user = usersDao.getById(currentUser.getId());
+//            model.addAttribute("user", user);
+//        }
+//        House houseFromDb = housesDao.getById(id);
+//        model.addAttribute("house", houseFromDb);
+//        model.addAttribute("states", states);
+//        if (currentUser.getId() == houseFromDb.getUser().getId()) {
+//            houseFromDb.setImage_url(null);
+//        }
+//        return "houses/edit";
+//    }
 }

--- a/src/main/java/com/agentlink/agentlink/controllers/UserController.java
+++ b/src/main/java/com/agentlink/agentlink/controllers/UserController.java
@@ -104,7 +104,7 @@ public class UserController {
         }
 
         model.addAttribute("hostingEvents", eventsDao.findAllByHostedByUserIdAndDateStartAfter(user.getId(), new Date()));
-        model.addAttribute("appliedEvents", appsDao.findAllByUserIdWhereNotHost(user.getId()));
+        model.addAttribute("appliedEvents", appsDao.findAllByUserIdWhereNotHostAndEventHasNotStarted(user.getId(), new Date()));
 
 
         return "users/profile";

--- a/src/main/java/com/agentlink/agentlink/repositories/ApplicationRepository.java
+++ b/src/main/java/com/agentlink/agentlink/repositories/ApplicationRepository.java
@@ -12,6 +12,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     List<Application> findAllByUserId(long id);
 
+    // Finds all applications by user id where the event applied to needs a host and the event has not started.
     @Query("FROM Application A WHERE A.user.id = ?1 AND A.openHouseEvent.user.id <> A.user.id AND A.openHouseEvent.dateStart >= ?2 ORDER BY A.openHouseEvent.dateStart")
     List<Application> findAllByUserIdWhereNotHostAndEventHasNotStarted(long id, Date date);
 

--- a/src/main/java/com/agentlink/agentlink/repositories/ApplicationRepository.java
+++ b/src/main/java/com/agentlink/agentlink/repositories/ApplicationRepository.java
@@ -4,6 +4,7 @@ import com.agentlink.agentlink.models.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Date;
 import java.util.List;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -11,7 +12,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     List<Application> findAllByUserId(long id);
 
-    @Query("FROM Application A WHERE A.user.id = ?1 AND A.openHouseEvent.user.id <> A.user.id")
-    List<Application> findAllByUserIdWhereNotHost(long id);
+    @Query("FROM Application A WHERE A.user.id = ?1 AND A.openHouseEvent.user.id <> A.user.id AND A.openHouseEvent.dateStart >= ?2 ORDER BY A.openHouseEvent.dateStart")
+    List<Application> findAllByUserIdWhereNotHostAndEventHasNotStarted(long id, Date date);
 
 }

--- a/src/main/resources/templates/houses/edit.html
+++ b/src/main/resources/templates/houses/edit.html
@@ -46,7 +46,7 @@
                         </div>
                         <div class="form-group mb-2">
                             <label for="filestack">Upload New House Picture</label>
-                            <button id="filestack" class="btn btn-sm btn-outline-dark">Select Image</button>
+                            <button id="filestack" class="btn btn-sm btn-outline-dark" type="button">Select Image</button>
                             <input type="hidden" th:value="${FILESTACK_TOKEN}" class="filestackToken">
                         </div>
                         <br>
@@ -54,21 +54,15 @@
                             <input type="submit" value="Save Changes" class="btn btn-block btn-color mt-2"/>
                         </div>
                         <!--DISPLAY HOUSE IMAGE-->
-                        <div th:if="${house.image_url != null}">
+                        <div>
                             <div class="mb-3 col-md-12 form-group">
-                                <h6> Here is your current house:</h6>
+                                <h6> Current house image:</h6>
                             </div>
                             <div class="mb-3 col-md-12 form-group">
                                 <img th:src="${house.image_url}" width="100%" height="100%" alt="House Picture">
                             </div>
                         </div>
                     </form>
-                    <!--HOUSE IMAGE DELETE BUTTON-->
-                    <div th:if="${house.image_url != null}" class="mb-3 col-md-12 form-group">
-                        <form th:action="@{/houses/delete/{id}/image (id = ${house.id})}" th:object="${house}" method="post">
-                            <input type="submit" class="btn btn-danger" value="Delete House Image"/>
-                        </form>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixed an issue with updating image button on edit listing page. 

Removed delete image option from edit listing page, now we can just upload a new image to overwrite an old one.

When creating a new listing if you do not upload an image a default image is used.